### PR TITLE
Fix gzip handling for error responses

### DIFF
--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -138,15 +138,18 @@ func Gzip(level int) func(http.Handler) http.Handler {
 			h.Set("Content-Encoding", "gzip")
 			h.Add("Vary", "Accept-Encoding")
 
-			recorder := &responseRecorder{ResponseWriter: w, status: http.StatusOK, writer: gw}
+			recorder := &responseRecorder{ResponseWriter: w, status: http.StatusOK, writer: gw, compressed: true}
+			recorder.closeFn = func() {
+				gw.Close()
+				pool.Put(gw)
+			}
 
 			defer func() {
 				if rec := recover(); rec != nil {
-					pool.Put(gw)
+					recorder.Close()
 					panic(rec)
 				}
-				gw.Close()
-				pool.Put(gw)
+				recorder.Close()
 			}()
 
 			next.ServeHTTP(recorder, r)
@@ -157,8 +160,10 @@ func Gzip(level int) func(http.Handler) http.Handler {
 // responseRecorder captures status and optionally wraps the writer.
 type responseRecorder struct {
 	http.ResponseWriter
-	status int
-	writer io.Writer
+	status     int
+	writer     io.Writer
+	closeFn    func()
+	compressed bool
 }
 
 func (rw *responseRecorder) WriteHeader(code int) {
@@ -171,6 +176,25 @@ func (rw *responseRecorder) Write(p []byte) (int, error) {
 		return rw.writer.Write(p)
 	}
 	return rw.ResponseWriter.Write(p)
+}
+
+func (rw *responseRecorder) Close() {
+	if rw.closeFn != nil {
+		rw.closeFn()
+		rw.closeFn = nil
+	}
+}
+
+func (rw *responseRecorder) DisableCompression() {
+	if !rw.compressed {
+		return
+	}
+	rw.compressed = false
+	rw.Close()
+	rw.writer = nil
+	header := rw.Header()
+	header.Del("Content-Encoding")
+	header.Del("Content-Length")
 }
 
 func randomID() string {


### PR DESCRIPTION
## Summary
- add a way for the gzip middleware to release its writer and drop headers when compression must be disabled
- ensure HTML error pages and JSON payloads opt out of compression before writing so their headers stay consistent