### PR TITLE
Use templated default error pages

### DIFF
--- a/internal/errors/defaults.go
+++ b/internal/errors/defaults.go
@@ -1,9 +1,64 @@
 package errors
 
-const (
-	// Default404 is used when no custom 404 page is provided.
-	Default404 = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Page Not Found</title><meta name="robots" content="noindex"></head><body><h1>404 Not Found</h1><p>The requested page could not be found.</p></body></html>`
+import (
+	"bytes"
+	"html/template"
+	"strings"
 
-	// Default500 is used when no custom 500 page is provided.
-	Default500 = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Server Error</title><meta name="robots" content="noindex"></head><body><h1>500 Internal Server Error</h1><p>Something went wrong.</p></body></html>`
+	_ "embed"
+
+	"github.com/elchemista/LandingGo/internal/pages"
 )
+
+var (
+	//go:embed templates/404.html
+	default404Source string
+	//go:embed templates/500.html
+	default500Source string
+
+	default404Template = parseTemplate("404.html", default404Source)
+	default500Template = parseTemplate("500.html", default500Source)
+)
+
+const (
+	fallback404 = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Page Not Found</title><meta name="robots" content="noindex"></head><body><h1>404 Not Found</h1><p>The requested page could not be found.</p></body></html>`
+	fallback500 = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Server Error</title><meta name="robots" content="noindex"></head><body><h1>500 Internal Server Error</h1><p>Something went wrong.</p></body></html>`
+)
+
+// Default404 renders the embedded 404 template using the provided page data.
+func Default404(data pages.PageData) []byte {
+	return renderTemplate(default404Template, data, fallback404)
+}
+
+// Default500 renders the embedded 500 template using the provided page data.
+func Default500(data pages.PageData) []byte {
+	return renderTemplate(default500Template, data, fallback500)
+}
+
+func renderTemplate(tmpl *template.Template, data pages.PageData, fallback string) []byte {
+	if tmpl == nil {
+		return []byte(fallback)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return []byte(fallback)
+	}
+
+	return buf.Bytes()
+}
+
+func parseTemplate(name, src string) *template.Template {
+	if strings.TrimSpace(src) == "" {
+		return nil
+	}
+
+	tmpl, err := template.New(name).
+		Option("missingkey=zero").
+		Parse(src)
+	if err != nil {
+		return nil
+	}
+
+	return tmpl
+}

--- a/internal/errors/defaults_test.go
+++ b/internal/errors/defaults_test.go
@@ -1,0 +1,39 @@
+package errors
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestDefaultTemplatesMirrorWebPages(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("unable to determine caller path")
+	}
+
+	root := filepath.Join(filepath.Dir(file), "..", "..", "web", "pages")
+
+	cases := []struct {
+		name     string
+		source   string
+		filename string
+	}{
+		{name: "404", source: default404Source, filename: "404.html"},
+		{name: "500", source: default500Source, filename: "500.html"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			want, err := os.ReadFile(filepath.Join(root, tc.filename))
+			if err != nil {
+				t.Fatalf("read %s: %v", tc.filename, err)
+			}
+
+			if string(want) != tc.source {
+				t.Fatalf("embedded template for %s does not match web/pages/%s", tc.name, tc.filename)
+			}
+		})
+	}
+}

--- a/internal/errors/templates/404.html
+++ b/internal/errors/templates/404.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Not Found</title>
+  <meta name="robots" content="noindex">
+  <link rel="stylesheet" href="/static/app.css">
+</head>
+<body class="space-y-6">
+  <h1 class="text-3xl font-bold text-rose-600">Custom 404</h1>
+  <p>No content lives at <code>{{.RoutePath}}</code>.</p>
+  <a class="nav-link" href="/">Return home</a>
+</body>
+</html>

--- a/internal/errors/templates/500.html
+++ b/internal/errors/templates/500.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Server Error</title>
+  <meta name="robots" content="noindex">
+  <link rel="stylesheet" href="/static/app.css">
+</head>
+<body class="space-y-6">
+  <h1 class="text-3xl font-bold text-rose-600">Custom 500</h1>
+  <p>We hit a snag processing <code>{{.RoutePath}}</code>. Please try again later.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- embed the 404 and 500 page templates so default error responses render the full HTML design
- render fallback error pages through templates to ensure dynamic data like the route path is included
- add tests to guarantee the embedded defaults stay in sync with the web/pages templates